### PR TITLE
have the contact working with fabform.io

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2625,9 +2625,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.3.tgz",
-      "integrity": "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
+      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
       "license": "MIT"
     },
     "node_modules/devlop": {

--- a/src/components/forms/FormContact.astro
+++ b/src/components/forms/FormContact.astro
@@ -1,8 +1,25 @@
 ---
+/*
+    DEVELOPER NOTE — FABFORM.IO INTEGRATION
+    FabForm.io is a backend service that accepts submissions from static HTML
+    forms. Astro generates static pages, so forms cannot submit anywhere unless
+    you provide a backend endpoint. FabForm solves this by giving you a unique
+    form URL that receives and stores submissions.
+
+    HOW TO USE FABFORM
+    1. Create a form endpoint at https://fabform.io
+    2. Copy your unique form URL (example: https://fabform.io/f/your-form-id)
+    3. Paste that URL into the <form action="..."> attribute below
+    4. Ensure each input has a valid `name` attribute
+*/
 ---
 
-<form action="#">
+<form 
+    action="https://fabform.io/f/REPLACE_WITH_YOUR_FORM_ID"
+    method="POST"
+>
     <div class="flex flex-col gap-8 mx-auto max-w-md">
+
         <div>
             <label for="name">Name</label>
             <div class="mt-2">
@@ -13,14 +30,25 @@
         <div>
             <label for="email">Email</label>
             <div class="mt-2 grid grid-cols-1">
-                <input type="email" name="email" id="email" placeholder="you@example.com" required />
+                <input 
+                    type="email" 
+                    name="email" 
+                    id="email" 
+                    placeholder="you@example.com" 
+                    required 
+                />
             </div>
         </div>
 
         <div>
             <label for="message">Message</label>
             <div class="mt-2">
-                <textarea name="message" id="message" rows="4" required></textarea>
+                <textarea 
+                    name="message" 
+                    id="message" 
+                    rows="4" 
+                    required
+                ></textarea>
             </div>
         </div>
 
@@ -45,3 +73,4 @@
         </div>
     </div>
 </form>
+


### PR DESCRIPTION

**Summary**  
This PR integrates the site’s contact form with **FabForm.io**, enabling fully functional form submissions without requiring a custom backend or server‑side code.

**What’s Changed**  
- Updated `FormContact.astro` to submit directly to a FabForm.io endpoint  
- Added clear developer‑facing HTML comments explaining:
  - What FabForm.io is  
  - Why it’s needed for static/Astro sites  
  - How to configure the form endpoint  
- No visual or UX changes for end‑users — all additions are internal developer documentation

**Why This Matters**  
Astro outputs static HTML by default, so forms cannot submit anywhere unless a backend exists.  
FabForm.io provides a secure, hosted form endpoint that handles submissions, storage, and notifications.  
This update makes the contact form fully operational across all hosting platforms (Vercel, Netlify, GitHub Pages, DigitalOcean, Cloudflare Pages, etc.).

**How to Configure**  
1. Create a form at https://fabform.io  
2. Copy the generated form URL  
3. Replace the placeholder `https://fabform.io/f/REPLACE_WITH_YOUR_FORM_ID` in `FormContact.astro`

**Testing**  
After inserting a real form ID, submit the form from the site and confirm the entry appears in the FabForm dashboard.

---
